### PR TITLE
Update acc-alarms.yang

### DIFF
--- a/acc-alarms.yang
+++ b/acc-alarms.yang
@@ -287,16 +287,13 @@ module acc-alarms {
             }
         }
         output {
-            container data {
-                presence "";
-                container alarms {
-                    uses alarms;
-                    description "output alarms";
-                }
-                container tcas {
-                    uses tcas;
-                    description "output tcas";
-                }
+            container alarms {
+                uses alarms;
+                description "output alarms";
+            }
+            container tcas {
+                uses tcas;
+                description "output tcas";
             }
         }
     }


### PR DESCRIPTION
remove the top container data from output parameter of rpc get-history-alarms