### PR TITLE
Update acc-devm.yang

### DIFF
--- a/acc-devm.yang
+++ b/acc-devm.yang
@@ -691,4 +691,12 @@ module acc-devm {
                 }
          }
     }
+    
+    rpc get-object-time {
+        output {
+            leaf date-time {
+                type yang:date-and-time;
+                }
+        }
+    }
 }


### PR DESCRIPTION
补充行标里遗漏的6.3.3.5章节，接口： get-object-time，