### PR TITLE
Update acc-devm.yang

### DIFF
--- a/acc-devm.yang
+++ b/acc-devm.yang
@@ -338,12 +338,14 @@ module acc-devm {
     */
     container me {
         leaf name {
+	    mandatory true;
             type string{
               length "1..64";
             }            
             description "name";
         }
         leaf uuid {
+	    mandatory true;
             type string;
             config false;
             description "Universal unique identifier, MAC address is suggested.";
@@ -693,7 +695,7 @@ module acc-devm {
          }
     }
 	
-	rpc get-object-time {
+	rpc get-managed-element-time {
         output {
             leaf date-time {
                 type yang:date-and-time;


### PR DESCRIPTION
1. 与set-managed-element-time对应，将原电信原名称get-object-time改名为set-managed-element-time，统一名称，三家运营商接口尽量统一
2. me里面的name和uuid增加了mandatory true，这两个字段应该是必须有的，否则yang.tree里会出现 uuid？  name？代表可选。