### PR TITLE
根据12月9日讨论结果，将eq-eth-pac修改为eth-mapping-pac，并增补到ETH PTP下

### DIFF
--- a/acc-eth.yang
+++ b/acc-eth.yang
@@ -224,34 +224,6 @@ module acc-eth {
         }
     }
 
-    augment "/acc-devm:eqs/acc-devm:eq" {
-        container eq-eth-pac {
-            leaf supported-mapping-type {
-                type eth-mapping-type;
-                description
-                  "none";
-            }
-            choice supported-server-switch-capability {
-                case odu-switch-capability-case {
-                    when "supported-server-ctp-layer = 'ODU'";
-                    leaf-list odu-switch-capability {
-                        type identityref {
-                            base otn-types:odu-type;
-                        }
-                        description "ODU Switch capability";
-                    }
-                }
-                case sdh-switch-capability-case {
-                    when "supported-server-ctp-layer = 'SDH'";
-                    leaf-list sdh-switch-capability {
-                        type acc-sdh:switch-type;
-                        description "SDH Switch capability";
-                    }
-                }
-            }
-            description "none";
-        }
-    }
     augment "/acc-devm:ptps/acc-devm:ptp" {
         when "acc-devm:layer-protocol-name = 'ETH'";
         container eth-ptp-pac {
@@ -299,14 +271,14 @@ module acc-eth {
             leaf lldp-peer-chassis-id {
                 config false;
                 type string {
-                    length 1..64;
+                    length 1..255;
                 }
                 description "none";
             }
             leaf lldp-peer-port-id {
                 config false;
                 type string {
-                    length 1..64;
+                    length 1..255;
                 }
                 description "none";
             }
@@ -314,6 +286,33 @@ module acc-eth {
                 config false;
                 type string {
                     length 1..64;
+                }
+            }
+            description "none";
+        }
+	
+	container eth-mapping-pac {
+            leaf supported-mapping-type {
+                type eth-mapping-type;
+                description
+                  "none";
+            }
+            choice supported-server-switch-capability {
+                case odu-switch-capability-case {
+                    when "supported-mapping-type = 'EoO'";
+                    leaf-list odu-switch-capability {
+                        type identityref {
+                            base otn-types:odu-type;
+                        }
+                        description "ODU Switch capability";
+                    }
+                }
+                case sdh-switch-capability-case {
+                    when "supported-mapping-type = 'EoS'";
+                    leaf-list sdh-switch-capability {
+                        type acc-sdh:switch-type;
+                        description "SDH Switch capability";
+                    }
                 }
             }
             description "none";


### PR DESCRIPTION
1）目前eth-mapping-pac为container，后续可根据使用情况，看看是否需要修订
2）lldp-peer-chassis-id和lldp-peer-port-id的长度本次提交未做修改（本次提交中的变动痕迹为我的本地库合入此前主干库对这两个字段长度修改的合入记录）